### PR TITLE
👍Recursive Export Database Integration

### DIFF
--- a/narkdown/exporter.py
+++ b/narkdown/exporter.py
@@ -5,7 +5,10 @@ from notion.client import NotionClient
 from notion.settings import *
 from .constants import *
 
+
 LOGN_PATH_PREFIX = '\\\\?\\'
+
+
 class NotionExporter:
     def __init__(
         self,

--- a/narkdown/exporter.py
+++ b/narkdown/exporter.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import requests
 import re
 from notion.client import NotionClient
@@ -6,7 +7,7 @@ from notion.settings import *
 from .constants import *
 
 
-LOGN_PATH_PREFIX = '\\\\?\\'
+WIN_LOGN_PATH_PREFIX = '\\\\?\\'
 
 
 class NotionExporter:
@@ -558,7 +559,10 @@ class NotionExporter:
 
 
 def create_directory(path):
-    if not (os.path.isdir(f"{LOGN_PATH_PREFIX}{path}")):
+    if platform.system() == 'Windows':
+        path = os.path.abspath(path)
+        path = f"{WIN_LOGN_PATH_PREFIX}{path}"
+    if not (os.path.isdir(path)):
         try:
             os.makedirs(path)
         except:


### PR DESCRIPTION
First, I have very recursive [notion page](doc.seongland.com) with `collection`
I wanted to export that, but with single export sequence with databases
So I modified collection export in recursive workflow with subpath support

### Feature
1. **`collection view` added to recursive export flow**

### Issue Resolve
1. **Long Path Support**
- windows has path limit 255
- but that can resolved by add prefix to absolute path ([reference](https://stackoverflow.com/questions/29557760/long-paths-in-python-on-windows))

2. Title Strip
if page start with new line charater, like below
![Uploading image.png…](like this)
narkdown can misunderstand **escape character** `\` as **directory separate character** so I striped `page`, `collection_view` title

